### PR TITLE
Elimina duplicado de sección 'Optimización de títulos y subtítulos' en reglas KDP

### DIFF
--- a/.windsurf/rules/kdp.md
+++ b/.windsurf/rules/kdp.md
@@ -16,9 +16,6 @@ Establecer lineamientos de optimización editorial y comercial para maximizar el
 
 ## Pasos automáticos
 
-### Optimización de títulos y subtítulos
-- Cada capítulo debe tener un título claro en el encabezado `#`
-- Subtítulos internos (`##`, `###`) deben reflejar ideas buscables y atractivas
 
 ### Optimización de títulos y subtítulos
 - Cada capítulo debe tener un título claro en el encabezado `#`


### PR DESCRIPTION
Se elimina la sección duplicada 'Optimización de títulos y subtítulos' en el archivo .windsurf/rules/kdp.md para evitar confusión y mantener la guía clara.\n\n- Solo queda una copia de la sección con los bullets esperados.\n- Se verificó que no hay otras duplicaciones de subsecciones.\n- El markdown mantiene su formato correcto.\n\nAntes:\n\n### Optimización de títulos y subtítulos\n- Cada capítulo debe tener un título claro en el encabezado \n- Subtítulos internos (, ) deben reflejar ideas buscables y atractivas\n\n### Optimización de títulos y subtítulos\n- Cada capítulo debe tener un título claro en el encabezado \n- Subtítulos internos (, ) deben reflejar ideas buscables y atractivas\n\nDespués:\n\n### Optimización de títulos y subtítulos\n- Cada capítulo debe tener un título claro en el encabezado \n- Subtítulos internos (, ) deben reflejar ideas buscables y atractivas\n